### PR TITLE
Fix installer level switches merge

### DIFF
--- a/src/installer/mod.rs
+++ b/src/installer/mod.rs
@@ -929,15 +929,18 @@ impl Installer {
                 )*
 
                 $(
-                    if let (Some(switch), Some(other_switch)) = (
-                        self.switches.$switch.as_mut(),
-                        other.switches.$switch.as_ref(),
-                    ) {
-                        for part in other_switch {
-                            if !switch.contains(part) {
-                                switch.push(part.clone());
+                    match (&mut self.switches.$switch, &other.switches.$switch) {
+                        (None, Some(other_switch)) => {
+                            self.switches.$switch = Some(other_switch.clone());
+                        },
+                        (Some(self_switch), Some(other_switch)) => {
+                            for part in other_switch {
+                                if !self_switch.contains(part) {
+                                    self_switch.push(part.clone());
+                                }
                             }
-                        }
+                        },
+                        _ => {}
                     }
                 )*
             };


### PR DESCRIPTION
Fixes switches at installer level not being carried over from previous manifest

```
komac update Bitwarden.Bitwarden -v 2025.5.0 -u https://github.com/bitwarden/clients/releases/download/desktop-v2025.5.0/Bitwarden-Installer-2025.5.0.exe\|neutral --dry-run
```
Before (Latest Nightly)
```yaml
- Architecture: neutral
  Scope: user
  InstallerUrl: https://github.com/bitwarden/clients/releases/download/desktop-v2025.4.2/Bitwarden-Installer-2025.4.2.exe
  InstallerSha256: E5DFF456E8CCECC37A2A5DB79670351649562D0E5FD2DA4D3FBB2751F179EA2F
  # Switches from previous version not carried over
- Architecture: neutral
  Scope: machine
  InstallerUrl: https://github.com/bitwarden/clients/releases/download/desktop-v2025.4.2/Bitwarden-Installer-2025.4.2.exe
  InstallerSha256: E5DFF456E8CCECC37A2A5DB79670351649562D0E5FD2DA4D3FBB2751F179EA2F
  # Switches from previous version not carried over
```
After
```yaml
- Architecture: neutral
  Scope: user
  InstallerUrl: https://github.com/bitwarden/clients/releases/download/desktop-v2025.5.0/Bitwarden-Installer-2025.5.0.exe
  InstallerSha256: F50B8EF22AC329679EE5BF690C2BFA58D19436D91861B3343871BAE28CD39F4E
  InstallerSwitches:
    Custom: /currentuser
- Architecture: neutral
  Scope: machine
  InstallerUrl: https://github.com/bitwarden/clients/releases/download/desktop-v2025.5.0/Bitwarden-Installer-2025.5.0.exe
  InstallerSha256: F50B8EF22AC329679EE5BF690C2BFA58D19436D91861B3343871BAE28CD39F4E
  InstallerSwitches:
    Custom: /allusers
```