### PR TITLE
Sort LanguageTag alphabetically

### DIFF
--- a/src/shared/language_tag.rs
+++ b/src/shared/language_tag.rs
@@ -45,6 +45,6 @@ impl PartialOrd for LanguageTag {
 
 impl Ord for LanguageTag {
     fn cmp(&self, other: &Self) -> Ordering {
-        other.0.total_cmp(&self.0)
+        self.0.total_cmp(&other.0)
     }
 }


### PR DESCRIPTION
I think it makes more sense to sort this alphabetically instead of reverse alphabetical order.